### PR TITLE
[ALLFEAT-57] Implementation of Contains trait

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,0 +1,9 @@
+use super::*;
+use frame_support::traits::Contains;
+
+// Expose a public API to check if an `AccountId` is an Artist or a Candidiate from other pallets.
+impl<T: Config> Contains<T::AccountId> for Pallet<T> {
+    fn contains(t: &T::AccountId) -> bool {
+        <Artists<T>>::contains_key(t) || <Candidates<T>>::contains_key(t)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod tests;
 
 mod functions;
 mod types;
+mod impls;
+
 pub use types::*;
 
 use frame_support::{


### PR DESCRIPTION
Expose the contains() fn for other pallets to check if an AccountId is an artist or a candidate.